### PR TITLE
Add libsndfile in Bindings

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@
 * [Qt](https://github.com/jokade/scalanative-qt5) - Bindings for [Qt](https://www.qt.io).
 * [ncurses](https://github.com/edadma/ncurses) - Bindings for the [GNU Ncurses Library](https://www.gnu.org/software/ncurses/).
 * [readline](https://github.com/edadma/readline) - Bindings for the [GNU Readline Library](https://www.gnu.org/software/readline/).
+* [libsndfile](https://github.com/edadma/libsndfile) - Bindings for the [Libsndfile](https://tiswww.cwru.edu/php/chet/libsndfile/rltop.html) C library for sampled sound manipulation.
 
 ## File Formats and Parsers
 * [msgpack4z](https://github.com/msgpack4z/msgpack4z-native) - Implementation of [MessagePack](https://msgpack.org/), a binary serialisation format.


### PR DESCRIPTION
Here's a link to the bindings library repository: https://github.com/edadma/libsndfile.

Here's the C library's website: http://libsndfile.github.io/libsndfile

Wikipedia article about *libsndfile*: https://en.wikipedia.org/wiki/Libsndfile